### PR TITLE
Change windows installer ARP entries to match this community version

### DIFF
--- a/utils/windows/installer/windows-installer.nsi
+++ b/utils/windows/installer/windows-installer.nsi
@@ -17,14 +17,14 @@ SetDatablockOptimize on
 
 ;Parse package.json
 
-!define APP_NAME "Stremio"
+!define APP_NAME "StremioCommunity"
 !define PRODUCT_VERSION "$%package_version%"
 !define ARCH "$%arch%"
 !searchparse "${PRODUCT_VERSION}" `` VERSION_MAJOR `.` VERSION_MINOR `.` VERSION_REVISION
-!define APP_URL "https://www.stremio.com"
+!define APP_URL "https://github.com/Zaarrg/stremio-community-v5"
 !define DATA_FOLDER "stremio"
 
-!define COMPANY_NAME "Smart Code Ltd"
+!define COMPANY_NAME "Zaarrg"
 
 
 ; ------------------- ;


### PR DESCRIPTION
Updates the windows installer entries to match this community version and differ from official Stremio

- Resolves https://github.com/microsoft/winget-pkgs/issues/335025
- Resolves #197 :)
- Related https://github.com/microsoft/winget-pkgs/pull/320876

> until the installer’s ARP metadata is adjusted

I have not tested the changes to see if the installer builds  
But I think this should be all there is to it

